### PR TITLE
Refactor request handling and add new behaviors/hooks

### DIFF
--- a/sample/SampleAPI/Behaviours/AuthenticationBehaviour.cs
+++ b/sample/SampleAPI/Behaviours/AuthenticationBehaviour.cs
@@ -1,0 +1,12 @@
+﻿
+namespace SampleAPI.Behaviours;
+
+public class AuthenticationBehaviour<TRequest, TResponse>(ILogger<AuthenticationBehaviour<TRequest, TResponse>> logger) : IPipelineBehaviour<TRequest, TResponse>
+{
+    public Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
+    {
+        logger.LogInformation("Behaviour: Authenticating request: {Request}", request);
+
+        return next();
+    }
+}

--- a/sample/SampleAPI/Behaviours/LoggingBehaviour.cs
+++ b/sample/SampleAPI/Behaviours/LoggingBehaviour.cs
@@ -1,0 +1,25 @@
+﻿using System.Diagnostics;
+
+namespace SampleAPI.Behaviours;
+
+public class LoggingBehaviour<TRequest, TResponse>(ILogger<LoggingBehaviour<TRequest, TResponse>> logger) : IPipelineBehaviour<TRequest, TResponse>
+{
+    public Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
+    {
+        var startTime = Stopwatch.GetTimestamp();
+
+        try
+        {
+            logger.LogInformation("Behaviour: Logging request: {Request}", request);
+
+            return next();
+
+        }
+        finally
+        {
+            var elapsedTime = Stopwatch.GetElapsedTime(startTime);
+
+            logger.LogInformation("Behaviour: Finished logging request: {Request}. Duration: {duration}", request, elapsedTime);
+        }
+    }
+}

--- a/sample/SampleAPI/Behaviours/ValidationBehaviour.cs
+++ b/sample/SampleAPI/Behaviours/ValidationBehaviour.cs
@@ -1,0 +1,17 @@
+﻿
+using SampleAPI.Dtos;
+
+namespace SampleAPI.Behaviours;
+
+public class ValidationBehaviour<TRequest, TResponse> : IPipelineBehaviour<TRequest, TResponse>
+{
+    public Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
+    {
+        if (request is CreateCityForecastCommand and { City: "" or null })
+        {
+            throw new ArgumentException("City name cannot be empty");
+        }
+
+        return next();
+    }
+}

--- a/sample/SampleAPI/Handlers/CityForecastHandler.cs
+++ b/sample/SampleAPI/Handlers/CityForecastHandler.cs
@@ -10,3 +10,11 @@ public class CityForecastHandler(WeatherForecastRepository forecastRepository) :
         return Task.FromResult(forecastRepository.Get(cityName));
     }
 }
+
+//public class CityForecast2Handler(WeatherForecastRepository forecastRepository) : RequestHandler<string, WeatherForecast?>
+//{
+//    public override Task<WeatherForecast?> HandleAsync(string cityName, CancellationToken cancellationToken = default)
+//    {
+//        return Task.FromResult(forecastRepository.Get(cityName));
+//    }
+//}

--- a/sample/SampleAPI/Hooks/CreateCityForcastAlertHook.cs
+++ b/sample/SampleAPI/Hooks/CreateCityForcastAlertHook.cs
@@ -1,0 +1,31 @@
+﻿
+using SampleAPI.Dtos;
+
+namespace SampleAPI.Hooks;
+
+public class CreateCityForcastAlertHook(ILogger<CreateCityForcastAlertHook> logger) : IRequestHook<CreateCityForecastCommand, Empty>
+{
+    public Task OnExecutingAsync(CreateCityForecastCommand request, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Hook Executing. New forcast for city: {city}", request.City);
+
+        if (request.WeatherForecast.TemperatureC < 0)
+        {
+            logger.LogWarning("It is gonna be cold!!!");
+        }
+
+        if (request.WeatherForecast.TemperatureC > 30)
+        {
+            logger.LogError("It is gonna be hot!!!");
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnExecutedAsync(CreateCityForecastCommand request, Empty response, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Hook Executed. New forcast for city: {city}", request.City);
+
+        return Task.CompletedTask;
+    }
+}

--- a/sample/SampleAPI/endpoints.http
+++ b/sample/SampleAPI/endpoints.http
@@ -4,7 +4,7 @@ GET {{SampleAPI_HostAddress}}/weatherforecast
 
 ###
 
-GET {{SampleAPI_HostAddress}}/weatherforecast/London
+GET {{SampleAPI_HostAddress}}/weatherforecast/Paris
 
 ###
 
@@ -12,10 +12,10 @@ POST {{SampleAPI_HostAddress}}/weatherforecast
 Content-Type: application/json
 
 {
-  "city": "Berlin",
+  "city": "",
   "weatherForecast":{
     "Date": "2024-08-30",
-    "TemperatureC": 25,
+    "TemperatureC": 55,
     "Summary": "Partly Cloudy"
   }
 }

--- a/src/EasyRequestHandlers.csproj
+++ b/src/EasyRequestHandlers.csproj
@@ -5,7 +5,7 @@
 	  <PackageId>EasyRequestHandler</PackageId>
 	<Authors>Juan Carlos Torres Cuervo</Authors>
 	 <Description>EasyRequestHandler is a lightweight .NET library designed to simplify event and request handling.</Description>
-	<VersionPrefix>1.0.5</VersionPrefix>
+	<VersionPrefix>1.0.6</VersionPrefix>
 	<PackageTags>.net, events, request-handlers</PackageTags>
 	<PackageProjectUrl>https://github.com/devjuanca/RequestHandler</PackageProjectUrl>
 	<RepositoryUrl>https://github.com/devjuanca/RequestHandler</RepositoryUrl>

--- a/src/Events/EventsRegister.cs
+++ b/src/Events/EventsRegister.cs
@@ -18,7 +18,7 @@ namespace EasyRequestHandlers.Events
         /// <param name="services">The <see cref="IServiceCollection"/> to which the event handlers will be added.</param>
         /// <param name="assemblyTypes">An array of types used to identify the assemblies containing event handlers.</param>
         /// <returns>The modified <see cref="IServiceCollection"/> containing the registered event handlers.</returns>
-        public static IServiceCollection AddEventsHandlers(this IServiceCollection services, params Type[] assemblyTypes)
+        public static IServiceCollection AddEasyEventHandlers(this IServiceCollection services, params Type[] assemblyTypes)
         {
 
             foreach (var type in assemblyTypes)

--- a/src/Request/IPipelineBehaviour.cs
+++ b/src/Request/IPipelineBehaviour.cs
@@ -1,0 +1,12 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace EasyRequestHandlers.Request
+{
+    public delegate Task<TResponse> RequestHandlerDelegate<TResponse>();
+
+    public interface IPipelineBehaviour<TRequest, TResponse>
+    {
+        Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next);
+    }
+}

--- a/src/Request/IRequestHook.cs
+++ b/src/Request/IRequestHook.cs
@@ -1,0 +1,12 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace EasyRequestHandlers.Request
+{
+    public interface IRequestHook<TRequest, TResponse>
+    {
+        Task OnExecutingAsync(TRequest request, CancellationToken cancellationToken);
+
+        Task OnExecutedAsync(TRequest request, TResponse response, CancellationToken cancellationToken);
+    }
+}

--- a/src/Request/ISender.cs
+++ b/src/Request/ISender.cs
@@ -1,0 +1,89 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EasyRequestHandlers.Request
+{
+    public interface ISender
+    {
+        Task<TResponse> SendAsync<TRequest, TResponse>(TRequest request, CancellationToken cancellationToken = default);
+
+        Task<TResponse> SendAsync<TResponse>(CancellationToken cancellationToken = default);
+    }
+
+    public class Sender : ISender
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        private readonly RequestHandlerOptions _options;
+
+        public Sender(IServiceProvider serviceProvider, RequestHandlerOptions options)
+        {
+            _serviceProvider = serviceProvider;
+
+            _options = options;
+        }
+
+        public Task<TResponse> SendAsync<TRequest, TResponse>(TRequest request, CancellationToken cancellationToken = default)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            var handler = _serviceProvider.GetRequiredService<RequestHandler<TRequest, TResponse>>();
+
+            var behaviors = _serviceProvider.GetServices<IPipelineBehaviour<TRequest, TResponse>>()
+                                            .Reverse()
+                                            .ToList();
+            List<IRequestHook<TRequest, TResponse>> hooks = new List<IRequestHook<TRequest, TResponse>>();
+
+            if (_options.EnableRequestHooks)
+            {
+                hooks = _serviceProvider.GetServices<IRequestHook<TRequest, TResponse>>().ToList();
+            }
+
+            RequestHandlerDelegate<TResponse> handlerDelegate = async () =>
+            {
+                if (_options.EnableRequestHooks)
+                {
+                    foreach (var hook in hooks)
+                    {
+                        await hook.OnExecutingAsync(request, cancellationToken);
+                    }
+                }
+
+                var response = await handler.HandleAsync(request, cancellationToken);
+
+                if (_options.EnableRequestHooks)
+                {
+                    foreach (var hook in hooks)
+                    {
+                        await hook.OnExecutedAsync(request, response, cancellationToken);
+                    }
+                }
+
+                return response;
+            };
+
+            foreach (var behavior in behaviors)
+            {
+                var next = handlerDelegate;
+
+                handlerDelegate = () => behavior.Handle(request, cancellationToken, next);
+            }
+
+            return handlerDelegate();
+        }
+
+        public Task<TResponse> SendAsync<TResponse>(CancellationToken cancellationToken = default)
+        {
+            var handler = _serviceProvider.GetRequiredService<RequestHandler<TResponse>>();
+
+            return handler.HandleAsync(cancellationToken);
+        }
+    }
+}

--- a/src/Request/RequestHandlerBuilder.cs
+++ b/src/Request/RequestHandlerBuilder.cs
@@ -1,0 +1,105 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using System;
+using System.Linq;
+
+namespace EasyRequestHandlers.Request
+{
+    public class RequestHandlerBuilder
+    {
+        private readonly IServiceCollection _services;
+
+        private readonly RequestHandlerOptions _options;
+
+        private readonly Type[] _assemblyMarkers;
+
+        public RequestHandlerBuilder(IServiceCollection services, RequestHandlerOptions options, Type[] assemblyMarkers)
+        {
+            _services = services;
+
+            _options = options;
+
+            _assemblyMarkers = assemblyMarkers;
+        }
+
+        public RequestHandlerBuilder WithMediatorPattern()
+        {
+            _options.EnableMediatorPattern = true;
+
+            return this;
+        }
+
+        public RequestHandlerBuilder RemoveHandlerInjection()
+        {
+            _options.EnableHandlerInjection = false;
+
+            return this;
+        }
+
+        public RequestHandlerBuilder WithBehaviour(Type openGenericBehaviour)
+        {
+            if (!_options.EnableMediatorPattern)
+            {
+                return this;
+            }
+
+            if (!openGenericBehaviour.IsGenericTypeDefinition)
+                throw new ArgumentException("Type must be an open generic like typeof(MyBehaviour<,>)");
+
+            var implementsInterface = openGenericBehaviour.GetInterfaces()
+                .Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IPipelineBehaviour<,>));
+
+            if (!implementsInterface)
+                throw new ArgumentException($"Type {openGenericBehaviour.Name} must implement IPipelineBehaviour<,>");
+
+            _services.TryAddEnumerable(
+                ServiceDescriptor.Transient(typeof(IPipelineBehaviour<,>), openGenericBehaviour));
+
+            return this;
+        }
+
+        public RequestHandlerBuilder WithBehaviours(params Type[] behaviourTypes)
+        {
+            if (!_options.EnableMediatorPattern)
+            {
+                return this;
+            }
+
+            foreach (var behaviourType in behaviourTypes)
+            {
+                if (!behaviourType.IsGenericTypeDefinition || behaviourType.GetGenericTypeDefinition() != behaviourType)
+                {
+                    throw new ArgumentException($"Behaviour type {behaviourType.Name} must be an open generic type, e.g. LoggingBehaviour<,>");
+                }
+
+                var implementsInterface = behaviourType.GetInterfaces()
+                    .Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IPipelineBehaviour<,>));
+
+                if (!implementsInterface)
+                {
+                    throw new ArgumentException($"Type {behaviourType.Name} must implement IPipelineBehaviour<,>");
+                }
+
+                _services.TryAddEnumerable(ServiceDescriptor.Transient(typeof(IPipelineBehaviour<,>), behaviourType));
+            }
+
+            return this;
+        }
+
+        public RequestHandlerBuilder WithRequestHooks()
+        {
+            _options.EnableRequestHooks = true;
+
+            return this;
+        }
+
+
+        public IServiceCollection Build()
+        {
+            HandlersRegister.RegisterHandlers(_services, _options, _assemblyMarkers);
+
+            return _services;
+        }
+    }
+
+}

--- a/src/Request/RequestHandlerOptions.cs
+++ b/src/Request/RequestHandlerOptions.cs
@@ -1,0 +1,11 @@
+﻿namespace EasyRequestHandlers.Request
+{
+    public class RequestHandlerOptions
+    {
+        internal bool EnableMediatorPattern { get; set; }
+
+        internal bool EnableRequestHooks { get; set; }
+
+        internal bool EnableHandlerInjection { get; set; } = true;
+    }
+}


### PR DESCRIPTION
- Introduced `CityForecast2Handler` alongside `CityForecastHandler`.
- Updated service registration in `Program.cs` to use `AddEasyRequestHandlers` and `AddEasyEventHandlers`.
- Changed expected city name and temperature in `endpoints.http` for test data.
- Incremented `EasyRequestHandlers` package version to `1.0.6`.
- Renamed handler registration methods to include "Easy" for clarity.
- Added new behaviors: `AuthenticationBehaviour`, `LoggingBehaviour`, and `ValidationBehaviour`.
- Introduced `CreateCityForcastAlertHook` for pre/post request processing.
- Defined `IPipelineBehaviour` and `IRequestHook` interfaces for standardized handling.
- Implemented `ISender` interface to encapsulate request sending logic.
- Enhanced `RequestHandlerBuilder` for better configuration options.
- Added `RequestHandlerOptions` class for customizable request handling settings.